### PR TITLE
Fixed issue when several destination files are indicated

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,14 @@ module.exports = function(grunt) {
         src: ['*.js','*.css'],
         dest: 'tmp/withPrefixAndSuffix.html'
       },
+      // we want to generates several files at the same time
+      severalFiles : {
+        files : [
+            { cwd: "test/fixtures/", src: ['first.js','first.css'], dest: 'tmp/first.html'},
+            { cwd: "test/fixtures/", src: ['second.js','second.css'], dest: 'tmp/second.html'},
+        ]
+
+      }
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Create templated list of files
 
 ## Getting Started
-This plugin requires Grunt `~0.4.1`
+This plugin requires Grunt `~1.0.1`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -87,4 +87,8 @@ grunt.initConfig({
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
-_(Nothing yet)_
+
+* 2017-09-13   v0.2.0   Compatibility with Grunt 1.0.1
+* 2014-01-22   v0.1.3   Fixed issue when several destination files are indicated
+* 2013-08-20   v0.1.2   First stable version
+

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This plugin requires Grunt `~1.0.1`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-files-list --save-dev
+npm install grunt-files-list2 --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('grunt-files-list');
+grunt.loadNpmTasks('grunt-files-list2');
 ```
 
 ## The "files_list" task
@@ -88,7 +88,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
-* 2017-09-13   v0.2.0   Compatibility with Grunt 1.0.1
+* 2017-09-13   v0.2.0   Compatibility with Grunt 1.0.1, and rename package to grunt-file-list2
 * 2014-01-22   v0.1.3   Fixed issue when several destination files are indicated
 * 2013-08-20   v0.1.2   First stable version
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-files-list",
   "description": "Create templated list of files",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "homepage": "https://github.com/motorin/grunt-files-list",
   "author": {
     "name": "Motorin",
@@ -28,13 +28,13 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.1"
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-clean": "~1.1.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt": "~1.0.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "~1.0.1"
   },
   "keywords": [
     "gruntplugin",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "grunt-files-list",
+  "name": "grunt-files-list2",
   "description": "Create templated list of files",
   "version": "0.2.0",
-  "homepage": "https://github.com/motorin/grunt-files-list",
+  "homepage": "https://github.com/laurentj/grunt-files-list2",
   "author": {
     "name": "Motorin",
     "email": "pavel.motorin@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/motorin/grunt-files-list.git"
+    "url": "git://github.com/laurentj/grunt-files-list2.git"
   },
   "bugs": {
-    "url": "https://github.com/motorin/grunt-files-list/issues"
+    "url": "https://github.com/laurentj/grunt-files-list2/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/motorin/grunt-files-list/blob/master/LICENSE-MIT"
+      "url": "https://github.com/laurentj/grunt-files-list2/blob/master/LICENSE-MIT"
     }
   ],
   "main": "Gruntfile.js",

--- a/tasks/files_list.js
+++ b/tasks/files_list.js
@@ -30,8 +30,6 @@ module.exports = function(grunt) {
       separator: '\r\n'
     });
 
-    var outputHTML = "";
-    var targetFile = "";
     var filesCounter = 0;
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -64,15 +62,13 @@ module.exports = function(grunt) {
       }).join(grunt.util.normalizelf(options.separator));
 
       // src += options.punctuation;
-      targetFile = f.dest;
-      outputHTML = src;
+      // Write the destination file.
+      grunt.file.write(f.dest, src);
+      grunt.log.writeln('File "' + f.dest + '" created.');
     });
-    // Write the destination file.
-    grunt.file.write(targetFile, outputHTML);
 
     // Print a success message.
     grunt.log.writeln('Result script/link tags: ' + filesCounter + '.');
-    grunt.log.writeln('File "' + targetFile + '" created.');
 
   });
 

--- a/tasks/files_list.js
+++ b/tasks/files_list.js
@@ -12,8 +12,6 @@
 
 module.exports = function(grunt) {
 
-  // Link to Underscore.js
-  var _ = grunt.util._;
   var path = require('path');
 
   // Please see the Grunt documentation for more information regarding task
@@ -51,9 +49,9 @@ module.exports = function(grunt) {
         filesCounter++;
         switch(path.extname(filepath)){
           case ".js":
-            return _.template(options.jsTemplate, {filename: filepath, pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix});
+            return grunt.template.process(options.jsTemplate, {data:{filename: filepath, pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix}});
           case ".css":
-            return _.template(options.cssTemplate, {filename: filepath,pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix});
+            return grunt.template.process(options.cssTemplate, {data:{filename: filepath,pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix}});
           default:
             filesCounter--;
             grunt.log.warn('Unrecognized file extension: ' + path.extname(filepath) + '. Must be .js or .css');

--- a/tasks/files_list.js
+++ b/tasks/files_list.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
-  grunt.registerMultiTask('files_list', 'Create files list in for jincluding in HTML', function() {
+  grunt.registerMultiTask('files_list', 'Create files list in for including in HTML', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       jsTemplate: '<script src="<%= pathPrefix %><%= filename %><%= pathSuffix %>"></script>',

--- a/test/expected/first.html
+++ b/test/expected/first.html
@@ -1,0 +1,2 @@
+<script src="first.js"></script>
+<link rel="stylesheet" type="text/css" href="first.css"></link>

--- a/test/expected/second.html
+++ b/test/expected/second.html
@@ -1,0 +1,2 @@
+<script src="second.js"></script>
+<link rel="stylesheet" type="text/css" href="second.css"></link>

--- a/test/files_list_test.js
+++ b/test/files_list_test.js
@@ -45,4 +45,16 @@ exports.files_list = {
 
     test.done();
   },
+  several_files: function(test) {
+    test.expect(2);
+
+    var actual = grunt.file.read('tmp/first.html');
+    var expected = grunt.file.read('test/expected/first.html');
+    test.equal(actual, expected, 'first generated file is ok');
+
+    actual = grunt.file.read('tmp/second.html');
+    expected = grunt.file.read('test/expected/second.html');
+    test.equal(actual, expected, 'second generated file is ok');
+    test.done();
+  },
 };


### PR DESCRIPTION
Grunt supports a list of files. However, even if files_list loops over this list, it creates only the last one. It should
generate all indicated files.
