### PR TITLE
[fix] template rendering

### DIFF
--- a/tasks/files_list.js
+++ b/tasks/files_list.js
@@ -53,9 +53,9 @@ module.exports = function(grunt) {
         filesCounter++;
         switch(path.extname(filepath)){
           case ".js":
-            return _.template(options.jsTemplate, {filename: filepath, pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix});
+            return _.template(options.jsTemplate)({filename: filepath, pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix});
           case ".css":
-            return _.template(options.cssTemplate, {filename: filepath,pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix});
+            return _.template(options.cssTemplate)({filename: filepath,pathPrefix: options.pathPrefix, pathSuffix: options.pathSuffix});
           default:
             filesCounter--;
             grunt.log.warn('Unrecognized file extension: ' + path.extname(filepath) + '. Must be .js or .css');


### PR DESCRIPTION
Without this fix the result looks like so (grunt-cli v1.2.0):
```javascript
function (obj) {
obj || (obj = {});
var __t, __p = '';
with (obj) {
__p += '<link rel="stylesheet" type="text/css" href="' +
((__t = ( pathPrefix )) == null ? '' : __t) +
'' +
((__t = ( filename )) == null ? '' : __t) +
'' +
((__t = ( pathSuffix )) == null ? '' : __t) +
'"></link>';

}
return __p
}
```